### PR TITLE
idris: fix building on GHC 7.8

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
@@ -48,16 +48,12 @@ self: super: {
   # haddock-api 2.16 requires ghc>=7.10
   haddock-api = super.haddock-api_2_15_0_2;
 
-  # Idris requires mtl 2.2.x.
+  # Idris requires old versions of some libraries
   idris = overrideCabal (super.idris.overrideScope (self: super: {
-    mkDerivation = drv: super.mkDerivation (drv // { doCheck = false; });
     blaze-markup = self.blaze-markup_0_6_2_0;
     blaze-html = self.blaze-html_0_7_0_3;
-    haskeline = self.haskeline_0_7_2_1;
+    annotated-wl-pprint = self.annotated-wl-pprint_0_5_3;
     lens = self.lens_4_7_0_1;
-    mtl = self.mtl_2_2_1;
-    transformers = super.transformers_0_4_3_0;
-    transformers-compat = disableCabalFlag super.transformers-compat "three";
   })) (drv: {
     patchPhase = "find . -name '*.hs' -exec sed -i -s 's|-Werror||' {} +";
   });                           # warning: "Module ‘Control.Monad.Error’ is deprecated"


### PR DESCRIPTION
Rebased. Also, I don't know why `haskeline`, `mtl` and others were overrided and why check was disabled. It works for me as is.
