### PR TITLE
Allow ghcjs to be jailbroken.

### DIFF
--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -80,6 +80,8 @@ in mkDerivation (rec {
   ];
   patches = [ ./ghcjs.patch ];
   postPatch = ''
+    echo "Run jailbreak-cabal to lift version restrictions on build inputs."
+    ${jailbreak-cabal}/bin/jailbreak-cabal ${pname}.cabal
     substituteInPlace Setup.hs \
       --replace "/usr/bin/env" "${coreutils}/bin/env"
 


### PR DESCRIPTION
This doesn't actually allow ghcjs to build right now, but it was _not_ being jailbroken, which means it was failing with attoparsec and lens mismatches.
