### PR TITLE
Fixes to packages affected by jailbreak-cabal problem

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -680,11 +680,8 @@ self: super: {
   # https://github.com/junjihashimoto/test-sandbox-compose/issues/2
   test-sandbox-compose = dontCheck super.test-sandbox-compose;
 
-  # https://github.com/jgm/pandoc/issues/2156
-  pandoc = overrideCabal (dontJailbreak super.pandoc) (drv: {
-    doCheck = false;    # https://github.com/jgm/pandoc/issues/2036
-    patchPhase = "sed -i -e 's|zlib .*,|zlib,|' -e 's|QuickCheck .*,|QuickCheck,|' pandoc.cabal";
-  });
+  # https://github.com/jgm/pandoc/issues/2036
+  pandoc = dontCheck super.pandoc;
 
   # Broken by GLUT update.
   Monadius = markBroken super.Monadius;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -807,10 +807,6 @@ self: super: {
   # Obsolete for GHC versions after GHC 6.10.x.
   utf8-prelude = markBroken super.utf8-prelude;
 
-  # https://github.com/jgm/cheapskate/issues/11
-  cheapskate = markBrokenVersion "0.1.0.3" super.cheapskate;
-  lit = dontDistribute super.lit;
-
   # https://github.com/snapframework/snap/issues/148
   snap = overrideCabal super.snap (drv: {
     patchPhase = "sed -i -e 's|attoparsec.*>=.*,|attoparsec,|' -e 's|lens.*>=.*|lens|' snap.cabal";

--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -48,6 +48,19 @@ self: super: {
   # https://ghc.haskell.org/trac/ghc/ticket/9921
   mkDerivation = drv: super.mkDerivation (drv // { doHoogle = false; });
 
+  idris =
+    let idris' = overrideCabal super.idris (drv: {
+      # "idris" binary cannot find Idris library otherwise while building.
+      # After installing it's completely fine though.
+      # Seems like Nix-specific issue so not reported.
+      preBuild = ''
+        export LD_LIBRARY_PATH=$PWD/dist/build:$LD_LIBRARY_PATH
+      '';
+    });
+    in idris'.overrideScope (self: super: {
+      zlib = self.zlib_0_5_4_2;
+    });
+
   Extra = appendPatch super.Extra (pkgs.fetchpatch {
     url = "https://github.com/seereason/sr-extra/commit/29787ad4c20c962924b823d02a7335da98143603.patch";
     sha256 = "193i1xmq6z0jalwmq0mhqk1khz6zz0i1hs6lgfd7ybd6qyaqnf5f";

--- a/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
@@ -75,6 +75,9 @@ self: super: {
   ghc-exactprint = dontDistribute super.ghc-exactprint;
   ghc-typelits-natnormalise = dontDistribute super.ghc-typelits-natnormalise;
 
+  # Needs directory >= 1.2.2.0.
+  idris = dontDistribute super.idris;
+
   # Newer versions require transformers 0.4.x.
   seqid = super.seqid_0_1_0;
   seqid-streams = super.seqid-streams_0_1_0;


### PR DESCRIPTION
Those require fix for https://github.com/peti/jailbreak-cabal/issues/9 in your tree, so cannot be applied to master right now. One weird thing is an issue with Idris (see patch); works fine though. Tested for GHC 7.8.4 and 7.10.1.
