### PR TITLE
Unmark gitlib broken.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -814,7 +814,6 @@ self: super: {
   });
 
   # https://github.com/jwiegley/gitlib/issues/46
-  gitlib = markBroken super.gitlib;
   gitlib-sample = dontDistribute super.gitlib-sample;
   gitlib-test = dontDistribute super.gitlib-test;
 


### PR DESCRIPTION
The newly release version should build.
