### PR TITLE
Don't try to build haddock for aeson-applicative.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -272,4 +272,7 @@ self: super: {
   # Won't work with LLVM 3.5.
   llvm-general = markBrokenVersion "3.4.5.3" super.llvm-general;
 
+  # Inexplicable haddock failure
+  # https://github.com/gregwebs/aeson-applicative/issues/2
+  aeson-applicative = dontHaddock super.aeson-applicative;
 }


### PR DESCRIPTION
I investigated this a bit, and the haddock looks entirely reasonable to my eye, and yet it fails to parse:

```
Running Haddock for aeson-applicative-0.1.0.0...
Preprocessing library aeson-applicative-0.1.0.0...
Haddock coverage:

Data/Aeson/JsonInfo.hs:38:21:
    parse error on input ‘-- ^ The accessor’
```

Reported as gregwebs/aeson-applicative#2
