### PR TITLE
ghcjs updates

### DIFF
--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -55,8 +55,8 @@ in mkDerivation (rec {
   inherit version;
   src = fetchgit {
     url = git://github.com/ghcjs/ghcjs.git;
-    rev = "c1b6239b0289371dc6b8d17dfd845c14bd4dc490"; # master branch
-    sha256 = "0ncbk7m1l7cpdgmabm14d7f97fw3vy0hmpj4vs4kkwhhfjf6kp8s";
+    rev = "fb1faa9cb0a11a8b27b0033dfdb07aafb6add35e"; # master branch
+    sha256 = "1vqf19059j86h3rnbvzcp55bdqd5dkw3krb5vkw5mgsmva2g8sch";
   };
   isLibrary = true;
   isExecutable = true;

--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -47,8 +47,8 @@ let
   };
   shims = fetchgit {
     url = git://github.com/ghcjs/shims.git;
-    rev = "9b196ff5ff13a24997011009b37c980c5534e24f"; # master branch
-    sha256 = "1zsfxka692fr3zb710il7g1sj64xwaxmasimciylb4wx84h7c30w";
+    rev = "0b670ca27fff3f0bad515c37e56ccb8b4d6758fb"; # master branch
+    sha256 = "19zq79f2y59lw7c8m100awh3rcra5yhbsvpb5xmp3mq6grac7h08";
   };
 in mkDerivation (rec {
   pname = "ghcjs";

--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -41,8 +41,8 @@ let
   version = "0.1.0";
   ghcjsBoot = fetchgit {
     url = git://github.com/ghcjs/ghcjs-boot.git;
-    rev = "d3581514d0a5073f8220a2f5baafe6866faa35a0"; # 7.10 branch
-    sha256 = "1p13ifidpi7y1mjq5qv9229isfnsiklizci7i55sf83mp6wqdyvr";
+    rev = "d435c60b62d24b7a4117493f7aaecbfa09968fe6"; # 7.10 branch
+    sha256 = "07vhmjz21ccnqccms003550xacmwb08pjdkhnjcwcbl2603v4na1";
     fetchSubmodules = true;
   };
   shims = fetchgit {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -895,7 +895,4 @@ self: super: {
   # https://ghc.haskell.org/trac/ghc/ticket/9825
   vimus = overrideCabal super.vimus (drv: { broken = pkgs.stdenv.isLinux && pkgs.stdenv.isi686; });
 
-  # https://github.com/yesodweb/Shelly.hs/issues/105
-  shelly = dontCheck super.shelly;
-
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -221,7 +221,7 @@ self: super: {
       });
 
   # Does not compile: "fatal error: ieee-flpt.h: No such file or directory"
-  base_4_8_0_0 = markBroken super.base_4_8_0_0;
+  base_4_8_1_0 = markBroken super.base_4_8_1_0;
 
   # Obsolete: https://github.com/massysett/prednote/issues/1.
   prednote-test = markBrokenVersion "0.26.0.4" super.prednote-test;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -870,6 +870,7 @@ self: super: {
   # This package can't be built on non-Windows systems.
   Win32 = overrideCabal super.Win32 (drv: { broken = !pkgs.stdenv.isCygwin; });
   inline-c-win32 = dontDistribute super.inline-c-win32;
+  Southpaw = dontDistribute super.Southpaw;
 
   # Doesn't work with recent versions of mtl.
   cron-compat = markBroken super.cron-compat;


### PR DESCRIPTION
This trio of patches---well, actually, using the ghcjs patch while it was in my mdorman/ghcjs tree, but something in nixos/unstable has set off a chain of rebuilds, so it would be a while before I could say for absolute certain, but I didn't have to change the SHA---gets ghcjs back to a buildable state.

This should resolve NixOS/nixpkgs#8948
