### PR TITLE
Use older tar with older ghcs

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.0.x.nix
@@ -70,4 +70,7 @@ self: super: {
   # Needs hashable on pre 7.10.x compilers.
   nats = addBuildDepend super.nats self.hashable;
 
+  # Work around bytestring >=0.10 requirement.
+  tar = super.tar_0_4_1_0;
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-7.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.2.x.nix
@@ -70,4 +70,7 @@ self: super: {
   # Needs hashable on pre 7.10.x compilers.
   nats = addBuildDepend super.nats self.hashable;
 
+  # Work around bytestring >=0.10 requirement.
+  tar = super.tar_0_4_1_0;
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-7.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.4.x.nix
@@ -73,6 +73,9 @@ self: super: {
   # Needs hashable on pre 7.10.x compilers.
   nats = addBuildDepend super.nats self.hashable;
 
+  # Work around bytestring >=0.10 requirement.
+  tar = super.tar_0_4_1_0;
+
   # Test suite won't compile.
   unix-time = dontCheck super.unix-time;
 


### PR DESCRIPTION
I think this, in combination with NixOs/cabal2nix#188, will fix building tar on older ghcs.
