### PR TITLE
Remove obsolete zip-archive override.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -265,9 +265,6 @@ self: super: {
   webkitgtk3-javascriptcore = super.webkitgtk3-javascriptcore.override { webkit = pkgs.webkitgtk24x; };
   websnap = super.websnap.override { webkit = pkgs.webkitgtk24x; };
 
-  # https://github.com/jgm/zip-archive/issues/21
-  zip-archive = addBuildTool super.zip-archive pkgs.zip;
-
   # https://github.com/mvoidex/hsdev/issues/11
   hsdev = dontHaddock super.hsdev;
 


### PR DESCRIPTION
Your patch was merged in in January, and examining hackage-packages.nix,
this dependency seems present.
