### PR TITLE
haskell-hbro is fixed.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -909,10 +909,6 @@ self: super: {
   # https://github.com/liyang/thyme/issues/36
   thyme = dontCheck super.thyme;
 
-  # https://github.com/k0ral/hbro/issues/15
-  hbro = markBroken super.hbro;
-  hbro-contrib = dontDistribute super.hbro-contrib;
-
   # https://github.com/aka-bash0r/multi-cabal/issues/4
   multi-cabal = markBroken super.multi-cabal;
 


### PR DESCRIPTION
He applied the patch quickly enough; I don't know why he didn't close
the bug you opened: k0ral/hbro#15
