### PR TITLE
Un-break ghc-mod on ghc-7.10.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -199,15 +199,6 @@ self: super: {
   pell = dontDistribute super.pell;
   quadratic-irrational = dontDistribute super.quadratic-irrational;
 
-  # https://github.com/kazu-yamamoto/ghc-mod/issues/437
-  ghc-mod = markBroken super.ghc-mod;
-  HaRe = dontDistribute super.HaRe;
-  ghc-imported-from = dontDistribute super.ghc-imported-from;
-  git-vogue = dontDistribute super.git-vogue;
-  haskell-token-utils = dontDistribute super.haskell-token-utils;
-  hbb = dontDistribute super.hbb;
-  hsdev = dontDistribute super.hsdev;
-
   # https://github.com/lymar/hastache/issues/47
   hastache = dontCheck super.hastache;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
@@ -91,4 +91,9 @@ self: super: {
   # blaze-builder requires an additional build input on older compilers.
   blaze-builder = addBuildDepend super.blaze-builder super.bytestring-builder;
 
+  # available convertible package won't build with the available
+  # bytestring and ghc-mod won't build without convertible
+  convertible = markBroken super.convertible;
+  ghc-mod = markBroken super.ghc-mod;
+
 }


### PR DESCRIPTION
The referenced bug kazu-yamamoto/ghc-mod#437 has been closed, and I have verified that the package builds and installs correctly with this patch applied under both ghc-7.10.2 and ghc-7.8.4.
