### PR TITLE
haskell-hbro: un-mark broken.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -899,10 +899,6 @@ self: super: {
   # https://github.com/liyang/thyme/issues/36
   thyme = dontCheck super.thyme;
 
-  # https://github.com/k0ral/hbro/issues/15
-  hbro = markBroken super.hbro;
-  hbro-contrib = dontDistribute super.hbro-contrib;
-
   # https://github.com/aka-bash0r/multi-cabal/issues/4
   multi-cabal = markBroken super.multi-cabal;
 


### PR DESCRIPTION
https://github.com/k0ral/hbro/issues/15 has been closed, a new version
has been released, and I have tested that both hbro and hbro-contrib
build on the current haskell-updates branch.
