### PR TITLE
haskell-ghcjs: use ghcjs compatible with new vector

### DIFF
--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -55,8 +55,8 @@ in mkDerivation (rec {
   inherit version;
   src = fetchgit {
     url = git://github.com/ghcjs/ghcjs.git;
-    rev = "fb1faa9cb0a11a8b27b0033dfdb07aafb6add35e"; # master branch
-    sha256 = "1vqf19059j86h3rnbvzcp55bdqd5dkw3krb5vkw5mgsmva2g8sch";
+    rev = "39c1cb6d5d2551b306a7957a0e7f682f4a048490"; # master branch
+    sha256 = "1v2hpmhdssgf1jmchiwkvp5j8j6rw3k0hpkf326vb8l1b0kbmibr";
   };
   isLibrary = true;
   isExecutable = true;


### PR DESCRIPTION
So there's a caveat here, and I don't know what you want to do about it.

There appears to be something wrong with the wrapper, and I have no idea how to fix it---I suspect it's been that way for some time.

```
~ $ ghcjs --help
/nix/store/zmd4jk4db5lgxb8l93mhkvr3x92g2sx2-bash-4.3-p39/bin/sh:  : No such file or directory
```

On the other hand:

```
~ $ sh ghcjs --help
Usage:

    ghcjs-0.1.0-7.10.2.bin [command-line-options-and-input-files]

To compile and link a complete Haskell program, run the compiler like
so:
...
```

I flat-out can't figure out what the issue is, though; the wrapper's so simple I don't see how it could fail, and everything I try to do to observe it perturbs it so it works---I copied the wrapper script and added -x so I could see what it's actually trying to execute, for instance, and it succeeds.

So this PR would make it _buildable_, but not straight-up _runnable_.
