### PR TITLE
haskell-types-compat: Re-enable haddock generation

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -157,7 +157,6 @@ self: super: {
   network-conduit = dontHaddock super.network-conduit;
   shakespeare-js = dontHaddock super.shakespeare-js;
   shakespeare-text = dontHaddock super.shakespeare-text;
-  types-compat = dontHaddock super.types-compat;                # https://github.com/philopon/apiary/issues/15
   wai-test = dontHaddock super.wai-test;
   zlib-conduit = dontHaddock super.zlib-conduit;
   record = dontHaddock super.record;                            # https://github.com/nikita-volkov/record/issues/22


### PR DESCRIPTION
The "real" issue (https://github.com/philopon/types-compat/issues/1) has
been closed for a while, and I manually confirmed that the documentation
builds correctly under 7.10.2 and 7.8.4.  The package itself doesn't
build older versions because of missing dependencies.
