### PR TITLE
hackage: add jb55 maintainer to skeletons project

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -82,6 +82,7 @@ package-maintainers:
     - located-base
     - target
   jb55:
+    - skeletons
     - cased
     - pipes-csv
     - pipes-mongodb


### PR DESCRIPTION
Figured I would do a PR here because I just pushed skeletons to hackage, and would rather it be here before you pushed the latest package set to nixpkgs. Wasn't sure though so let me know.
