### PR TITLE
Trigger rebuild on hlibgit2.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -211,4 +211,7 @@ self: super: {
   # Re-build this package to fix broken binaries on Hydra.
   math-functions = triggerRebuild super.math-functions 2;
 
+  # Re-build this package to fix broken binaries on Hydra.
+  hlibgit2 = triggerRebuild super.hlibgit2 1;
+
 }


### PR DESCRIPTION
This allows gitlib-libgit2 (and this git-monitor) to build properly.
