### PR TITLE
ghc-imported-from: builds again

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -1259,7 +1259,6 @@ dont-distribute-packages:
   ghc-exactprint:                               [ x86_64-darwin ]
   ghci-diagrams:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghci-haskeline:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghc-imported-from:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghclive:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-parmake:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-pkg-autofix:                              [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
The maintainer recently updated it to work with current ghc and ghc-mod.  It's built successfully on my machine, seems like a candidate to build automatically?
