### PR TITLE
Fixup zip-archive zip dependency.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -17,6 +17,8 @@ self: super: {
   # Apply NixOS-specific patches.
   ghc-paths = appendPatch super.ghc-paths ./patches/ghc-paths-nix.patch;
 
+  zip-archive = super.zip-archive.override { zip = pkgs.zip; };
+
   # Break infinite recursions.
   clock = dontCheck super.clock;
   Dust-crypto = dontCheck super.Dust-crypto;


### PR DESCRIPTION
Ensure that the correct zip is being used as a dep.  Tested by making sure it was no longer scheduled to be rebuilt.
