### PR TITLE
haddock-api: Don't use incompatible version with ghc-7.10

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -181,6 +181,9 @@ self: super: {
   # https://github.com/haskell/haddock/issues/427
   haddock = dontCheck super.haddock;
 
+  # haddock-api >= 2.17 is GHC 8.0 only
+  haddock-api = self.haddock-api_2_16_1;
+
   # The tests in vty-ui do not build, but vty-ui itself builds.
   vty-ui = enableCabalFlag super.vty-ui "no-tests";
 


### PR DESCRIPTION
haddock-api 2.17 is expressly incompatible with ghc-7.10, but a recent update cause it to become the "default" version, so we need an override.
