### PR TITLE
pandoc: jailbreak on ghc-8.0.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -165,4 +165,5 @@ self: super: {
 
   # MonadCatchIO-transformers = doJailbreak super.MonadCatchIO-transformers;
 
+  pandoc = doJailbreak super.pandoc;
 }


### PR DESCRIPTION
Without this change, pandoc fails to configure, complaining of unsatisfied dependencies when attempting to compile with ghc-8.0.1.  That said, I haven't been able to verify the build yet.
