### PR TITLE
Cabal, cabal-install: fix common expressions

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -7,8 +7,8 @@ self: super: {
   # Some packages need a non-core version of Cabal.
   Cabal_1_18_1_7 = dontCheck super.Cabal_1_18_1_7;
   Cabal_1_20_0_4 = dontCheck super.Cabal_1_20_0_4;
-  Cabal_1_22_4_0 = dontCheck super.Cabal_1_22_4_0;
-  cabal-install = (dontCheck super.cabal-install).overrideScope (self: super: { Cabal = self.Cabal_1_22_4_0; });
+  Cabal_1_22_4_0 = (dontCheck super.Cabal_1_22_4_0).overrideScope (self: super: { binary = self.binary_0_7_6_1; });
+  cabal-install = (dontCheck super.cabal-install).overrideScope (self: super: { Cabal = self.Cabal_1_24_0_0; });
   cabal-install_1_18_1_0 = (dontCheck super.cabal-install_1_18_1_0).overrideScope (self: super: { Cabal = self.Cabal_1_18_1_7; });
 
   # Link statically to avoid runtime dependency on GHC.


### PR DESCRIPTION
Cabal-1.22 requires an older version of binary.

In my build tests, it actually seemed like we could remove the
cabal-install override entirely, but at the very least, we need to point
it at the appropriate Cabal library.

Build tested under 7.10.3 and 8.0.1.
