### PR TITLE
haskellPackages.lambdabot: maintain

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2296,6 +2296,7 @@ package-maintainers:
     - shakespeare
   abbradar:
     - Agda
+    - lambdabot
 
 dont-distribute-packages:
   # hard restrictions that really belong into meta.platforms
@@ -5418,9 +5419,6 @@ dont-distribute-packages:
   lambda-toolbox:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambda2js:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdaBase:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lambdabot-haskell-plugins:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lambdabot-utils:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lambdabot:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdacat:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdacms-core:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdacms-media:                              [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
###### Motivation for this change

Maintain lambdabot (and transitive dependencies, but there are too many to specify).

Build is fixed in https://github.com/NixOS/nixpkgs/commit/713918a094d7d6ad0d75aea16e4b1f5b316f8c59 and https://github.com/NixOS/nixpkgs/commit/32560d26998fb593d512ac8dce0946486bb299f1.
