### PR TITLE
Groundwork for `gobjectIntrospection` cleanup

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -424,6 +424,9 @@ self: super: builtins.intersectAttrs super {
   gi-javascriptcore = super.gi-javascriptcore.override { webkitgtk = pkgs.webkitgtk24x; };
   gi-webkit = super.gi-webkit.override { webkit = pkgs.webkitgtk24x; };
 
+  # Requires gi-javascriptcore API version 4
+  gi-webkit2 = super.gi-webkit2.override { gi-javascriptcore = self.gi-javascriptcore_4_0_11; };
+
   # requires valid, writeable $HOME
   hatex-guide = overrideCabal super.hatex-guide (drv: {
     preConfigure = ''

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -420,6 +420,9 @@ self: super: builtins.intersectAttrs super {
   # tests require git
   hapistrano = addBuildTool super.hapistrano pkgs.git;
 
+  # This propagates this to everything depending on haskell-gi-base
+  haskell-gi-base = addBuildDepend super.haskell-gi-base pkgs.gobjectIntrospection;
+
   # requires webkitgtk API version 3 (webkitgtk 2.4 is the latest webkit supporting that version)
   gi-javascriptcore = super.gi-javascriptcore.override { webkitgtk = pkgs.webkitgtk24x; };
   gi-webkit = super.gi-webkit.override { webkit = pkgs.webkitgtk24x; };


### PR DESCRIPTION
###### Motivation for this change

The first change is a simple dependency fix for `gi-webkit2`---it needs to be built with the more recent `gi-javascriptcore`.

The second change paves the way for us to remove a bunch of cruft from `cabal2nix` by centralizing the propagation of `gobjectIntrospection` to a haskell package that everything's going to depend on _anyway_, rather than having to duplicate it all over.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

