### PR TITLE
dbus: haskell package no longer needs patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -775,10 +775,6 @@ self: super: {
   # horribly outdated (X11 interface changed a lot)
   sindre = markBroken super.sindre;
 
-  # https://github.com/jmillikin/haskell-dbus/pull/7
-  # http://hydra.cryp.to/build/498404/log/raw
-  dbus = dontCheck (appendPatch super.dbus ./patches/hdbus-semicolons.patch);
-
   # Test suite occasionally runs for 1+ days on Hydra.
   distributed-process-tests = dontCheck super.distributed-process-tests;
 


### PR DESCRIPTION
###### Motivation for this change

Without this change, it fails to build

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

