### PR TITLE
haskell-src-exts: retain 1.19 version

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2539,7 +2539,7 @@ extra-packages:
   - haddock-library == 1.2.*            # required for haddock-api-2.16.x
   - happy <1.19.6                       # newer versions break Agda
   - haskell-gi-overloading == 0.0       # gi-* packages use this dependency to disable overloading support
-  - haskell-src-exts == 1.18.*          # required by hoogle-5.0.4
+  - haskell-src-exts == 1.19.*          # required by hindent and structured-haskell-mode
   - language-c == 0.7.0                 # required by c2hs hack to work around https://github.com/haskell/c2hs/issues/192.
   - mtl < 2.2                           # newer versions require transformers > 0.4.x, which we cannot provide in GHC 7.8.x
   - mtl-prelude < 2                     # required for to build postgrest on mtl 2.1.x platforms


### PR DESCRIPTION
So I *believe* this is the right change to make, but please double-check.