### PR TITLE
ghc 8.{2,4}: Add patches for deterministic profiling symbols.

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -85,6 +85,10 @@ stdenv.mkDerivation rec {
       url = "https://git.haskell.org/ghc.git/commitdiff_plain/2fc8ce5f0c8c81771c26266ac0b150ca9b75c5f3";
       sha256 = "03253ci40np1v6k0wmi4aypj3nmj3rdyvb1k6rwqipb30nfc719f";
     })
+    (fetchpatch { # Backport of https://phabricator.haskell.org/D4388 for more determinism
+      url = "https://github.com/shlevy/ghc/commit/fec1b8d3555c447c0d8da0e96b659be67c8bb4bc.patch";
+      sha256 = "1lyysz6hfd1njcigpm8xppbnkadqfs0kvrp7s8vqgb38pjswj5hg";
+    })
   ];
 
   postPatch = "patchShebangs .";

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -3,7 +3,7 @@
 
 # build-tools
 , bootPkgs, alex, happy
-, autoconf, automake, coreutils, fetchgit, perl, python3
+, autoconf, automake, coreutils, fetchgit, fetchpatch, perl, python3
 
 , libffi, libiconv ? null, ncurses
 
@@ -80,6 +80,13 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   outputs = [ "out" "doc" ];
+
+  patches = [
+    (fetchpatch { # https://phabricator.haskell.org/D4388 for more determinism
+      url = "https://github.com/shlevy/ghc/commit/8b2dbd869d1a64de3e99fa8b1c9bb1140eee7099.patch";
+      sha256 = "0hxpiwhbg64rsyjdr4psh6dwyp58b96mad3adccvfr0x8hc6ba2m";
+    })
+  ];
 
   postPatch = "patchShebangs .";
 


### PR DESCRIPTION
These are taken from https://phabricator.haskell.org/D4388 (which is
against HEAD) and fix an inconsistency when building profiling
libraries on multiple machines that leads to linking failure.