### PR TITLE
ghc: Make deterministic profiling patches opt-in.

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -26,6 +26,10 @@
     !(targetPlatform.isDarwin
       # On iOS, dynamic linking is not supported
       && (targetPlatform.isAarch64 || targetPlatform.isArm))
+, # Whether to backport https://phabricator.haskell.org/D4388 for
+  # deterministic profiling symbol names, at the cost of a slightly
+  # non-standard GHC API
+  deterministicProfiling ? false
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -85,11 +89,11 @@ stdenv.mkDerivation rec {
       url = "https://git.haskell.org/ghc.git/commitdiff_plain/2fc8ce5f0c8c81771c26266ac0b150ca9b75c5f3";
       sha256 = "03253ci40np1v6k0wmi4aypj3nmj3rdyvb1k6rwqipb30nfc719f";
     })
+  ] ++ stdenv.lib.optional deterministicProfiling
     (fetchpatch { # Backport of https://phabricator.haskell.org/D4388 for more determinism
       url = "https://github.com/shlevy/ghc/commit/fec1b8d3555c447c0d8da0e96b659be67c8bb4bc.patch";
       sha256 = "1lyysz6hfd1njcigpm8xppbnkadqfs0kvrp7s8vqgb38pjswj5hg";
-    })
-  ];
+    });
 
   postPatch = "patchShebangs .";
 

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -25,6 +25,10 @@
   enableShared ? true
 
 , version ? "8.4.0.20180204"
+, # Whether to backport https://phabricator.haskell.org/D4388 for
+  # deterministic profiling symbol names, at the cost of a slightly
+  # non-standard GHC API
+  deterministicProfiling ? false
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -81,12 +85,11 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "doc" ];
 
-  patches = [
+  patches = stdenv.lib.optional deterministicProfiling
     (fetchpatch { # https://phabricator.haskell.org/D4388 for more determinism
       url = "https://github.com/shlevy/ghc/commit/8b2dbd869d1a64de3e99fa8b1c9bb1140eee7099.patch";
       sha256 = "0hxpiwhbg64rsyjdr4psh6dwyp58b96mad3adccvfr0x8hc6ba2m";
-    })
-  ];
+    });
 
   postPatch = "patchShebangs .";
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1000,20 +1000,21 @@ self: super: {
     '';
   });
 
-  # Fix for our backport of D4388 to GHC 8.2. This is in
-  # configuration-common because we will need the same patch if/when
-  # liquidhaskell is bumped to support GHC 8.4
-  # https://github.com/ucsd-progsys/liquidhaskell/pull/1233
-  liquidhaskell =
-    let patch = pkgs.fetchpatch
-          { url = https://github.com/ucsd-progsys/liquidhaskell/commit/635338e6ef0aec01d4f6a21058cabd24a521e63f.patch;
-            sha256 = "0lg40qn2w3kn6zk5r38mp6hndpnswzrqhk38059h0ljhw9md72s8";
-          };
-    in appendPatch super.liquidhaskell patch;
-
   # https://github.com/nick8325/twee/pull/1
   twee-lib = dontHaddock super.twee-lib;
 
   # Needs older hlint
   hpio = dontCheck super.hpio;
+
+  # Add a flag to enable building against GHC with D4388 applied (the
+  # deterministic profiling symbols patch). The flag is disabled by
+  # default, so we can apply this patch globally.
+  #
+  # https://github.com/ucsd-progsys/liquidhaskell/pull/1233
+  liquidhaskell =
+    let patch = pkgs.fetchpatch
+          { url = https://github.com/ucsd-progsys/liquidhaskell/commit/1aeef1871760b2be46cc1cabd51311997d1d0bc0.patch;
+            sha256 = "0i55n6p3x9as648as0lvxy2alqb1n7c10xv9gp15cvq7zx6c8ydg";
+          };
+    in appendPatch super.liquidhaskell patch;
 }


### PR DESCRIPTION
The patch changes some pieces of the exposed API, so we can't have our
default GHC changed in this way.