### PR TITLE
hpack_0_25_0: reinstate for cabal2nix

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2695,6 +2695,7 @@ extra-packages:
   - haskell-gi-overloading == 0.0       # gi-* packages use this dependency to disable overloading support
   - haskell-src-exts == 1.19.*          # required by hindent and structured-haskell-mode
   - hoogle == 5.0.14                    # required by hie-hoogle
+  - hpack == 0.25.0                     # required by cabal2nix
   - inline-c < 0.6                      # required on GHC 8.0.x
   - inline-c-cpp < 0.2                  # required on GHC 8.0.x
   - language-c == 0.7.0                 # required by c2hs hack to work around https://github.com/haskell/c2hs/issues/192.


### PR DESCRIPTION
Apparently the move to 0.26.0 involved huge API changes.