### PR TITLE
language-c: remove now-unnecessary overrides

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -833,7 +833,7 @@ self: super: {
       rev = "8b79823c32e234c161baec67fdf7907952ca62b8";
       sha256 = "0hyrcyssclkdfcw2kgcark8jl869snwnbrhr9k0a9sbpk72wp7nz";
     };
-  }).override { language-c = self.language-c_0_7_2; };
+  });
 
   # Needs pginit to function and pgrep to verify.
   tmp-postgres = overrideCabal super.tmp-postgres (drv: {

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -113,12 +113,6 @@ self: super: {
   hspec-discover = super.hspec-discover_2_4_8;
 
   ## Needs bump to a versioned attribute
-  ##     Ambiguous occurrence ‘<>’
-  ##     It could refer to either ‘Prelude.<>’,
-  ##                              imported from ‘Prelude’ at src/Language/C/Pretty.hs:15:8-24
-  language-c = super.language-c_0_7_2;
-
-  ## Needs bump to a versioned attribute
   ## Setup: Encountered missing dependencies:
   ## free ==4.*, template-haskell >=2.4 && <2.13
   lens = super.lens_4_16;


### PR DESCRIPTION
I'm certain about removing the override in configuration-common.nix, but I'm far less certain about the ghc-8.4-specific one.