### PR TITLE
Four evaluation fixes

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -603,13 +603,10 @@ self: super: {
       ln -s $lispdir $data/share/emacs/site-lisp
     '';
     doCheck = false; # https://github.com/chrisdone/hindent/issues/299
-  })).override {
-    haskell-src-exts = self.haskell-src-exts_1_20_2;
-  };
+  }));
 
   # Need newer versions of their dependencies than the ones we have in LTS-11.x.
   cabal2nix = super.cabal2nix.overrideScope (self: super: { hpack = self.hpack_0_28_0; hackage-db = self.hackage-db_2_0_1; });
-  hlint = super.hlint.overrideScope (self: super: { haskell-src-exts = self.haskell-src-exts_1_20_2; });
 
   # https://github.com/bos/configurator/issues/22
   configurator = dontCheck super.configurator;
@@ -847,14 +844,8 @@ self: super: {
 
   # Hoogle needs newer versions than lts-11 provides. lambdabot-haskell-plugins
   # depends on Hoogle and therefore needs to use the same version.
-  hoogle = super.hoogle.override {
-    haskell-src-exts = self.haskell-src-exts_1_20_2;
-  };
   lambdabot-haskell-plugins = super.lambdabot-haskell-plugins.override {
     haskell-src-exts-simple = self.haskell-src-exts-simple_1_20_0_0;
-  };
-  haskell-src-exts-simple_1_20_0_0 = super.haskell-src-exts-simple_1_20_0_0.override {
-    haskell-src-exts = self.haskell-src-exts_1_20_2;
   };
 
   # These packages depend on each other, forming an infinite loop.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -94,7 +94,7 @@ self: super: {
 
     # the tests for shell-conduit on Darwin illegitimatey assume non-GNU echo
     # see: https://github.com/psibi/shell-conduit/issues/12
-    doCheck = !pkgs.stdenv.hostPlatform.isDarwin;
+    doCheck = !pkgs.stdenv.isDarwin;
   }));
 
   # https://github.com/froozen/kademlia/issues/2

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -352,12 +352,6 @@ self: super: {
   th-printf = dontCheck super.th-printf;
   thumbnail-plus = dontCheck super.thumbnail-plus;
   tickle = dontCheck super.tickle;
-  tldr = super.tldr.override {
-    # shell-conduit determines what commands are available at compile-time, so
-    # that tldr will not compile unless the shell-conduit it uses is compiled
-    # with git in its environment.
-    shell-conduit = addBuildTool self.shell-conduit pkgs.git;
-  };
   tpdb = dontCheck super.tpdb;
   translatable-intset = dontCheck super.translatable-intset;
   ua-parser = dontCheck super.ua-parser;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -849,7 +849,6 @@ self: super: {
   # depends on Hoogle and therefore needs to use the same version.
   hoogle = super.hoogle.override {
     haskell-src-exts = self.haskell-src-exts_1_20_2;
-    http-conduit = self.http-conduit_2_3_0;
   };
   lambdabot-haskell-plugins = super.lambdabot-haskell-plugins.override {
     haskell-src-exts-simple = self.haskell-src-exts-simple_1_20_0_0;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -118,12 +118,6 @@ self: super: {
   });
 
   ## Needs bump to a versioned attribute
-  ##     • Could not deduce (Semigroup (ParseResult m))
-  ##         arising from the superclasses of an instance declaration
-  ##       from the context: Monoid m
-  haskell-src-exts = super.haskell-src-exts_1_20_2;
-
-  ## Needs bump to a versioned attribute
   hspec = overrideCabal super.hspec_2_4_8 (drv: {
     ## Setup: Encountered missing dependencies:
     ## hspec-core ==2.4.4, hspec-discover ==2.4.4


### PR DESCRIPTION
###### Motivation for this change

Without all of these (except for the `isDarwin` change, which is just a cosmetic consistency issue), you can't even evaluate `allPackages`.

###### Things done

Build is proceeding on NixOS, but it'll take a while.