### PR TITLE
gtk-traymanager: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -143,6 +143,7 @@ self: super: builtins.intersectAttrs super {
   gtk3 = disableHardening (super.gtk3.override { inherit (pkgs) gtk3; }) ["fortify"];
   gtk = disableHardening (addPkgconfigDepend (addBuildTool super.gtk self.gtk2hs-buildtools) pkgs.gtk2) ["fortify"];
   gtksourceview2 = addPkgconfigDepend super.gtksourceview2 pkgs.gtk2;
+  gtk-traymanager = addPkgconfigDepend super.gtk-traymanager pkgs.gtk3;
 
   # Need WebkitGTK, not just webkit.
   webkit = super.webkit.override { webkit = pkgs.webkitgtk24x-gtk2; };


### PR DESCRIPTION
So this doesn't really fix the build, it just moves the place that the build fails from being "we don't have the gtk version we need" to "eggtray code is apparently now too old"; I've reported the problem to the upstream author, but I'm thinking that if we can get reproducible failures in hydra, we might be in a better position to ask him to spend his time on it.