### PR TITLE
haskell-gi, gi-gdkx11: fix builds

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -422,6 +422,9 @@ self: super: {
   # https://github.com/evanrinehart/mikmod/issues/1
   mikmod = addExtraLibrary super.mikmod pkgs.libmikmod;
 
+  haskell-gi = dontCheck super.haskell-gi;
+  gi-gdkx11 = super.gi-gdkx11.override { gdk-x11 = pkgs.gtk3; };
+
   # https://github.com/basvandijk/threads/issues/10
   threads = dontCheck super.threads;
 


### PR DESCRIPTION
The `haskell-gi` build fails its doctests because of a missing
library; I'm not 100% convinced that setting it to `dontCheck` is the
right thing to do, but I don't have a better idea at the moment.

The `gi-gdkx11` build fails because, surprise, Gdk-X11 isn't found; by
looking around in my store, I found that that that library seems to
live in gtk3 these days; this override is just a stop-gap, though,
I've also submitted the change to cabal2nix that I believe will fix
the automatic generation of the package in the future.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

