### PR TITLE
Issue #32631

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -391,6 +391,9 @@ stdenv.mkDerivation ({
         local pkgId=$( ${gnused}/bin/sed -n -e 's|^id: ||p' $packageConfFile )
         mv $packageConfFile $packageConfDir/$pkgId.conf
       done
+
+      # delete confdir if there are no libraries
+      find $packageConfDir -maxdepth 0 -empty -delete;
     ''}
     ${optionalString isGhcjs ''
       for exeDir in "$out/bin/"*.jsexe; do


### PR DESCRIPTION
If empty directory isn't deleted, referer depenedencies will
fail with:

cp: missing destination file operand after '/tmp/nix-build-cabal-helper-0.8.0.2.drv-0/setup-package.conf.d/'

This is currently only the case for cabal-install, as cabal2nix
doesn't handle well buildable=False flags due to long-standing bugs
in Cabal itself.